### PR TITLE
enable btc price with cryptobridge exchange

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -15,7 +15,8 @@ var mongoose = require('mongoose')
   , cryptopia = require('./markets/cryptopia')
   , yobit = require('./markets/yobit')
   , empoex = require('./markets/empoex')
-  , ccex = require('./markets/ccex');
+  , ccex = require('./markets/ccex')
+  , cryptobridge = require("./markets/cryptobridge");
 //  , BTC38 = require('./markets/BTC38');
 
 function find_address(hash, cb) {
@@ -227,6 +228,11 @@ function get_market_data(market, cb) {
       break;
     case 'empoex':
       empoex.get_data(settings.markets.coin, settings.markets.exchange, function(err, obj){
+        return cb(err, obj);
+      });
+      break;
+    case "cryptobridge":
+      cryptobridge.get_data(settings.markets.coin, settings.markets.exchange, function(err, obj) {
         return cb(err, obj);
       });
       break;
@@ -577,6 +583,8 @@ module.exports = {
   update_markets_db: function(market, cb) {
     get_market_data(market, function (err, obj) {
       if (err == null) {
+        console.log("making market")
+        console.log(JSON.stringify(obj))
         Markets.update({market:market}, {
           chartdata: JSON.stringify(obj.chartdata),
           buys: obj.buys,
@@ -584,6 +592,8 @@ module.exports = {
           history: obj.trades,
           summary: obj.stats,
         }, function() {
+          console.log("making stats")
+          console.log(JSON.stringify(obj))
           if ( market == settings.markets.default ) {
             Stats.update({coin:settings.coin}, {
               last_price: obj.stats.last,

--- a/lib/markets/cryptobridge.js
+++ b/lib/markets/cryptobridge.js
@@ -1,0 +1,59 @@
+const request = require("request");
+const base_url = "https://api.crypto-bridge.org/api/v1";
+
+function get_summary(coin, exchange, cb) {
+    let req_url = base_url + "/ticker";
+    request({
+        uri: req_url,
+        json: true
+    }, (error, response, body) => {
+        let err = (error) => {return cb(error, null);}
+        if (error) err(error);
+
+        let market;
+        for(let m = 0; m < body.length; m++) {
+            market = body[m];
+            if (market.id === coin+"_"+exchange) {
+                break;
+            }
+        }
+        if(typeof market === undefined) err("Couldn't get market.");
+        
+        return cb(null, {
+            volume: market.volume,
+            last: market.last,
+            bid: market.bid,
+            ask: market.ask
+        })
+    });
+}
+
+function get_trades(coin, exchange, cb) {
+    return cb(null, [], []); //no possibility to get trades from CB
+}
+
+function get_orders(coin, exchange, cb) {
+    return cb(null, []); //no possibility to get orders from CB
+}
+
+module.exports = {
+    get_data: function (coin, exchange, cb) {
+        let error = null;
+        get_orders(coin, exchange, (err, buys, sells) => {
+            if (err) {error = err;}
+            get_trades(coin, exchange, (err, trades) => {
+                if (err) {error = err;}
+                get_summary(coin, exchange, (err, stats) => {
+                    if (err) {error = err;}
+                    return cb(error,{
+                        buys: buys,
+                        sells: sells,
+                        chartData: [],
+                        trades: trades,
+                        stats: stats
+                    })
+                })
+            })
+        })
+    }
+}


### PR DESCRIPTION
this enables the "BTC Price" panel on the explorer homepage to update with the last price from cryptobridge. simply change under settings.json:

```
  "markets": {
    "enabled": ["cryptobridge"],
    "default": "cryptobridge"
  }
```
the database will also contain a history of the volume, last price, bids and asks.

trade history and order history are not supported as there is no way to get this data from cryptobridge (or bitshares) api.